### PR TITLE
Edit sample data's remarks and tags

### DIFF
--- a/src/main/java/friday/model/student/Consultation.java
+++ b/src/main/java/friday/model/student/Consultation.java
@@ -73,7 +73,7 @@ public class Consultation {
     @Override
     public String toString() {
         String str = isEmpty() ? "" : value.toString();
-        return String.format("Consultation: %s", str);
+        return str;
     }
 
     @Override

--- a/src/main/java/friday/model/student/MasteryCheck.java
+++ b/src/main/java/friday/model/student/MasteryCheck.java
@@ -72,7 +72,7 @@ public class MasteryCheck {
     @Override
     public String toString() {
         String str = isEmpty() ? "" : value.toString();
-        return String.format("Mastery Check: %s", str);
+        return str;
     }
 
     @Override

--- a/src/main/java/friday/model/student/Remark.java
+++ b/src/main/java/friday/model/student/Remark.java
@@ -28,7 +28,7 @@ public class Remark {
 
     @Override
     public String toString() {
-        return value;
+        return String.format("Remark(s): %s", value);
     }
 
     @Override

--- a/src/main/java/friday/model/student/Remark.java
+++ b/src/main/java/friday/model/student/Remark.java
@@ -28,7 +28,7 @@ public class Remark {
 
     @Override
     public String toString() {
-        return String.format("Remark(s): %s", value);
+        return value;
     }
 
     @Override

--- a/src/main/java/friday/model/tag/Tag.java
+++ b/src/main/java/friday/model/tag/Tag.java
@@ -9,8 +9,8 @@ import static java.util.Objects.requireNonNull;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric. Whitespaces are allowed.";
+    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9 ]*$";
 
     public final String tagName;
 

--- a/src/main/java/friday/model/util/SampleDataUtil.java
+++ b/src/main/java/friday/model/util/SampleDataUtil.java
@@ -26,27 +26,27 @@ public class SampleDataUtil {
         return new Student[] {
             new Student(new Name("Alex Yeoh"), new TelegramHandle("al3xx"), new Consultation(LocalDate.now()),
                 new MasteryCheck(LocalDate.of(2022, 8, 16)), EMPTY_REMARK,
-                getTagSet("friends")),
+                getTagSet("Colour blind")),
             new Student(new Name("Bernice Yu"), new TelegramHandle("bernice123"),
                     new Consultation(LocalDate.of(2022, 9, 1)),
                     new MasteryCheck(LocalDate.of(2022, 7, 30)), new Remark("Weak at recursion"),
-                    getTagSet("colleagues", "friends")),
+                    getTagSet("Fast learner")),
             new Student(new Name("Charlotte Oliveiro"), new TelegramHandle("char_oli"),
                     new Consultation(LocalDate.of(2021, 10, 21)),
                     new MasteryCheck(LocalDate.of(2022, 12, 27)), new Remark("Smart"),
-                    getTagSet("neighbours")),
+                    getTagSet("Dyslexic")),
             new Student(new Name("David Li"), new TelegramHandle("d4vid"),
                     new Consultation(LocalDate.of(2022, 6, 17)),
                     new MasteryCheck(LocalDate.of(2022, 11, 11)), EMPTY_REMARK,
-                    getTagSet("family")),
+                    getTagSet("Needs more help")),
             new Student(new Name("Irfan Ibrahim"), new TelegramHandle("irfan72345"),
                     new Consultation(LocalDate.of(2025, 2, 20)),
                     new MasteryCheck(LocalDate.of(2020, 9, 1)), EMPTY_REMARK,
-                    getTagSet("classmates")),
+                    getTagSet("Cool guy")),
             new Student(new Name("Roy Balakrishnan"), new TelegramHandle("i_am_roy"),
                     new Consultation(LocalDate.of(2022, 7, 12)),
                     new MasteryCheck(LocalDate.of(2029, 9, 26)), EMPTY_REMARK,
-                    getTagSet("colleagues"))
+                    getTagSet("Fast learner"))
         };
     }
 

--- a/src/main/java/friday/ui/PersonCard.java
+++ b/src/main/java/friday/ui/PersonCard.java
@@ -52,9 +52,9 @@ public class PersonCard extends UiPart<Region> {
         id.setText(displayedIndex + ". ");
         name.setText(student.getName().fullName);
         telegramHandle.setText(student.getTelegramHandle().toString());
-        masteryCheck.setText(student.getMasteryCheck().toString());
-        consultation.setText(student.getConsultation().toString());
-        remark.setText(student.getRemark().toString());
+        masteryCheck.setText(String.format("Mastery Check: %s", student.getMasteryCheck().toString()));
+        consultation.setText(String.format("Consultation: %s", student.getConsultation().toString()));
+        remark.setText(String.format("Remark(s): %s", student.getRemark().toString()));
         student.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/java/friday/ui/PersonCard.java
+++ b/src/main/java/friday/ui/PersonCard.java
@@ -54,7 +54,7 @@ public class PersonCard extends UiPart<Region> {
         telegramHandle.setText(student.getTelegramHandle().toString());
         masteryCheck.setText(student.getMasteryCheck().toString());
         consultation.setText(student.getConsultation().toString());
-        remark.setText(student.getRemark().value);
+        remark.setText(student.getRemark().toString());
         student.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/test/java/friday/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/friday/logic/parser/EditCommandParserTest.java
@@ -20,6 +20,7 @@ import friday.testutil.EditPersonDescriptorBuilder;
 public class EditCommandParserTest {
 
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
+    private static final String INVALID_TAG = "*" + PREFIX_TAG;
 
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
@@ -77,11 +78,9 @@ public class EditCommandParserTest {
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
         // parsing it together with a valid tag results in error
         CommandParserTestUtil.assertParseFailure(parser, "1" + CommandTestUtil.TAG_DESC_FRIEND
-                + CommandTestUtil.TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
+                + CommandTestUtil.TAG_DESC_HUSBAND + INVALID_TAG, Tag.MESSAGE_CONSTRAINTS);
         CommandParserTestUtil.assertParseFailure(parser, "1" + CommandTestUtil.TAG_DESC_FRIEND
-                + TAG_EMPTY + CommandTestUtil.TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
-        CommandParserTestUtil.assertParseFailure(parser, "1" + TAG_EMPTY + CommandTestUtil.TAG_DESC_FRIEND
-                + CommandTestUtil.TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
+                + INVALID_TAG + CommandTestUtil.TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
     }
 
     @Test

--- a/src/test/java/friday/model/tag/TagTest.java
+++ b/src/test/java/friday/model/tag/TagTest.java
@@ -13,7 +13,7 @@ public class TagTest {
 
     @Test
     public void constructor_invalidTagName_throwsIllegalArgumentException() {
-        String invalidTagName = "";
+        String invalidTagName = "*";
         assertThrows(IllegalArgumentException.class, () -> new Tag(invalidTagName));
     }
 


### PR DESCRIPTION
Previously, there was no signposting in the GUI and PersonCard to indicate the Remarks field. The tags in the sample data also did not match the purpose of FRIDAY.

Added "Remark(s):" label to PersonCard and changed the tags in the sample data to be more relevant to FRIDAY.