### PR TITLE
Update alias feature

### DIFF
--- a/src/main/java/friday/logic/commands/AliasCommand.java
+++ b/src/main/java/friday/logic/commands/AliasCommand.java
@@ -50,7 +50,7 @@ public class AliasCommand extends Command {
             throw new CommandException(MESSAGE_INVALID_KEYWORD);
         }
 
-        if (!Alias.isValidAlias(toAdd)) {
+        if (!Alias.isValidAlias(toAdd.toString())) {
             throw new CommandException(MESSAGE_INVALID_ALIAS);
         }
 

--- a/src/main/java/friday/model/Friday.java
+++ b/src/main/java/friday/model/Friday.java
@@ -58,7 +58,7 @@ public class Friday implements ReadOnlyFriday {
     /**
      * Replaces the contents of the alias map with alias, keyword pair.
      */
-    public void setAliases(Set<Map.Entry<String, String>> aliases) {
+    public void setAliases(Set<Map.Entry<Alias, ReservedKeyword>> aliases) {
         this.aliases.setAliases(aliases);
     }
 
@@ -114,17 +114,9 @@ public class Friday implements ReadOnlyFriday {
     /**
      * Returns true if an alias with the same identity as {@code alias} exists in FRIDAY.
      */
-    public boolean hasAlias(String alias) {
-        requireNonNull(alias);
-        return aliases.contains(alias);
-    }
-
-    /**
-     * Returns true if an alias with the same identity as {@code alias} exists in FRIDAY.
-     */
     public boolean hasAlias(Alias alias) {
         requireNonNull(alias);
-        return aliases.contains(alias.toString());
+        return aliases.contains(alias);
     }
 
     /**
@@ -173,7 +165,7 @@ public class Friday implements ReadOnlyFriday {
     }
 
     @Override
-    public Set<Map.Entry<String, String>> getAliasMap() {
+    public Set<Map.Entry<Alias, ReservedKeyword>> getAliasMap() {
         return aliases.entrySet();
     }
 

--- a/src/main/java/friday/model/Model.java
+++ b/src/main/java/friday/model/Model.java
@@ -100,11 +100,6 @@ public interface Model {
     boolean hasAlias(Alias alias);
 
     /**
-     * Returns true if an alias with the same value as {@code key} exists in FRIDAY.
-     */
-    boolean hasAlias(String key);
-
-    /**
      * Adds an alias that maps to keyword to FRIDAY.
      * The alias must not already exist in FRIDAY.
      * The keyword must be a valid reserved keyword.

--- a/src/main/java/friday/model/ModelManager.java
+++ b/src/main/java/friday/model/ModelManager.java
@@ -117,12 +117,6 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean hasAlias(String alias) {
-        requireNonNull(alias);
-        return friday.hasAlias(alias);
-    }
-
-    @Override
     public boolean hasAlias(Alias alias) {
         requireNonNull(alias);
         return friday.hasAlias(alias);

--- a/src/main/java/friday/model/ReadOnlyFriday.java
+++ b/src/main/java/friday/model/ReadOnlyFriday.java
@@ -3,6 +3,8 @@ package friday.model;
 import java.util.Map;
 import java.util.Set;
 
+import friday.model.alias.Alias;
+import friday.model.alias.ReservedKeyword;
 import friday.model.student.Student;
 import javafx.collections.ObservableList;
 
@@ -21,6 +23,6 @@ public interface ReadOnlyFriday {
      * Returns a Set view of the mappings contained in alias map.
      * This set will not contain any duplicate aliases.
      */
-    Set<Map.Entry<String, String>> getAliasMap();
+    Set<Map.Entry<Alias, ReservedKeyword>> getAliasMap();
 
 }

--- a/src/main/java/friday/model/alias/Alias.java
+++ b/src/main/java/friday/model/alias/Alias.java
@@ -20,8 +20,8 @@ public class Alias {
         value = alias;
     }
 
-    public static boolean isValidAlias(Alias test) {
-        return !ReservedKeyword.LIST_RESERVED_KEYWORDS.contains(test.toString());
+    public static boolean isValidAlias(String test) {
+        return !ReservedKeyword.LIST_RESERVED_KEYWORDS.contains(test);
     }
 
     @Override

--- a/src/main/java/friday/model/alias/Alias.java
+++ b/src/main/java/friday/model/alias/Alias.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Represents an Alias in FRIDAY.
- * Guarantees: immutable; is always valid
  */
 public class Alias {
 
@@ -20,6 +19,9 @@ public class Alias {
         value = alias;
     }
 
+    /**
+     * Returns if a given String is a valid alias.
+     */
     public static boolean isValidAlias(String test) {
         return !ReservedKeyword.LIST_RESERVED_KEYWORDS.contains(test);
     }

--- a/src/main/java/friday/model/alias/AliasMap.java
+++ b/src/main/java/friday/model/alias/AliasMap.java
@@ -15,12 +15,12 @@ import friday.model.alias.exceptions.DuplicateAliasException;
  */
 public class AliasMap {
 
-    private final Map<String, String> internalMap = new HashMap<>();
+    private final Map<Alias, ReservedKeyword> internalMap = new HashMap<>();
 
     /**
      * Returns true if the hashmap contains an alias with value {@code key}.
      */
-    public boolean contains(String key) {
+    public boolean contains(Alias key) {
         requireNonNull(key);
         return internalMap.containsKey(key);
     }
@@ -34,10 +34,10 @@ public class AliasMap {
         requireNonNull(toAdd);
         requireNonNull(keyword);
         assert ReservedKeyword.isValidReservedKeyword(keyword.toString());
-        if (contains(toAdd.toString())) {
+        if (contains(toAdd)) {
             throw new DuplicateAliasException();
         }
-        internalMap.put(toAdd.toString(), keyword.toString());
+        internalMap.put(toAdd, keyword);
     }
 
     /**
@@ -46,10 +46,10 @@ public class AliasMap {
      */
     public void remove(Alias toRemove) {
         requireNonNull(toRemove);
-        if (!contains(toRemove.toString())) {
+        if (!contains(toRemove)) {
             throw new AliasNotFoundException();
         }
-        internalMap.remove(toRemove.toString());
+        internalMap.remove(toRemove);
     }
 
     /**
@@ -58,8 +58,9 @@ public class AliasMap {
      */
     public String getKeyword(String toFind) {
         requireNonNull(toFind);
-        if (contains(toFind)) {
-            return internalMap.get(toFind);
+        Alias temp = new Alias(toFind);
+        if (contains(temp)) {
+            return internalMap.get(temp).toString();
         }
         return toFind;
     }
@@ -68,18 +69,18 @@ public class AliasMap {
      * Returns a Set view of the mappings contained in alias map.
      * This set will not contain any duplicate aliases.
      */
-    public Set<Map.Entry<String, String>> entrySet() {
+    public Set<Map.Entry<Alias, ReservedKeyword>> entrySet() {
         return internalMap.entrySet();
     }
 
     /**
      * Replaces the contents of this map with alias, keyword pair.
      */
-    public void setAliases(Set<Map.Entry<String, String>> aliases) {
+    public void setAliases(Set<Map.Entry<Alias, ReservedKeyword>> aliases) {
         requireAllNonNull(aliases);
-        for (Map.Entry<String, String> aliasKeywordPair : aliases) {
-            Alias alias = new Alias(aliasKeywordPair.getKey());
-            ReservedKeyword keyword = new ReservedKeyword(aliasKeywordPair.getValue());
+        for (Map.Entry<Alias, ReservedKeyword> aliasKeywordPair : aliases) {
+            Alias alias = aliasKeywordPair.getKey();
+            ReservedKeyword keyword = aliasKeywordPair.getValue();
             add(alias, keyword);
         }
     }
@@ -89,10 +90,10 @@ public class AliasMap {
      */
     public String displayAliases() {
         String result = "";
-        Set<Map.Entry<String, String>> keyValuePairs = entrySet();
-        for (Map.Entry<String, String> keyValuePair : keyValuePairs) {
-            String key = keyValuePair.getKey();
-            String value = keyValuePair.getValue();
+        Set<Map.Entry<Alias, ReservedKeyword>> keyValuePairs = entrySet();
+        for (Map.Entry<Alias, ReservedKeyword> keyValuePair : keyValuePairs) {
+            String key = keyValuePair.getKey().toString();
+            String value = keyValuePair.getValue().toString();
             result = result + "\n" + key + " : " + value;
         }
         return result;

--- a/src/main/java/friday/model/alias/ReservedKeyword.java
+++ b/src/main/java/friday/model/alias/ReservedKeyword.java
@@ -12,6 +12,7 @@ import friday.logic.commands.DeleteCommand;
 import friday.logic.commands.EditCommand;
 import friday.logic.commands.ExitCommand;
 import friday.logic.commands.FindCommand;
+import friday.logic.commands.GradeCommand;
 import friday.logic.commands.HelpCommand;
 import friday.logic.commands.ListCommand;
 import friday.logic.commands.MarkMasteryCheckCommand;
@@ -27,10 +28,11 @@ import friday.logic.commands.UnaliasCommand;
 public class ReservedKeyword {
 
     public static final List<String> LIST_RESERVED_KEYWORDS = List.of(AddCommand.COMMAND_WORD,
-            AliasCommand.COMMAND_WORD, ClearCommand.COMMAND_WORD, DeleteCommand.COMMAND_WORD, EditCommand.COMMAND_WORD,
-            ExitCommand.COMMAND_WORD, FindCommand.COMMAND_WORD, HelpCommand.COMMAND_WORD, ListCommand.COMMAND_WORD,
+            AliasCommand.COMMAND_WORD, AliasListCommand.COMMAND_WORD, ClearCommand.COMMAND_WORD,
+            DeleteCommand.COMMAND_WORD, EditCommand.COMMAND_WORD, ExitCommand.COMMAND_WORD, FindCommand.COMMAND_WORD,
+            GradeCommand.COMMAND_WORD, HelpCommand.COMMAND_WORD, ListCommand.COMMAND_WORD,
             MarkMasteryCheckCommand.COMMAND_WORD, RemarkCommand.COMMAND_WORD, SortCommand.COMMAND_WORD,
-            UgCommand.COMMAND_WORD, UnaliasCommand.COMMAND_WORD, AliasListCommand.COMMAND_WORD);
+            UgCommand.COMMAND_WORD, UnaliasCommand.COMMAND_WORD);
 
     public static final String MESSAGE_CONSTRAINTS = "Reserved keyword given is not in the list of reserved keywords";
 

--- a/src/main/java/friday/model/alias/ReservedKeyword.java
+++ b/src/main/java/friday/model/alias/ReservedKeyword.java
@@ -23,7 +23,6 @@ import friday.logic.commands.UnaliasCommand;
 
 /**
  * Represents a ReservedKeyword in friday.
- * Guarantees: immutable; is always valid
  */
 public class ReservedKeyword {
 
@@ -48,6 +47,9 @@ public class ReservedKeyword {
         value = reservedKeyword;
     }
 
+    /**
+     * Returns if a given string is a valid reserved keyword.
+     */
     public static boolean isValidReservedKeyword(String test) {
         return LIST_RESERVED_KEYWORDS.contains(test);
     }

--- a/src/main/java/friday/storage/JsonAdaptedAlias.java
+++ b/src/main/java/friday/storage/JsonAdaptedAlias.java
@@ -33,9 +33,9 @@ class JsonAdaptedAlias {
     /**
      * Converts a given {@code Map.Entry} into this class for Jackson use.
      */
-    public JsonAdaptedAlias(Map.Entry<String, String> source) {
-        alias = source.getKey();
-        keyword = source.getValue();
+    public JsonAdaptedAlias(Map.Entry<Alias, ReservedKeyword> source) {
+        alias = source.getKey().toString();
+        keyword = source.getValue().toString();
     }
 
     /**

--- a/src/main/java/friday/storage/JsonAdaptedAlias.java
+++ b/src/main/java/friday/storage/JsonAdaptedAlias.java
@@ -23,9 +23,7 @@ class JsonAdaptedAlias {
      * Constructs a {@code JsonAdaptedAlias} with the given alias details.
      */
     @JsonCreator
-
     public JsonAdaptedAlias(@JsonProperty("alias") String alias, @JsonProperty("reservedKeyword") String keyword) {
-
         this.alias = alias;
         this.keyword = keyword;
     }

--- a/src/test/java/friday/logic/commands/AddCommandTest.java
+++ b/src/test/java/friday/logic/commands/AddCommandTest.java
@@ -162,11 +162,6 @@ public class AddCommandTest {
         }
 
         @Override
-        public boolean hasAlias(String key) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
         public void addAlias(Alias alias, ReservedKeyword keyword) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/friday/logic/commands/AliasCommandTest.java
+++ b/src/test/java/friday/logic/commands/AliasCommandTest.java
@@ -14,48 +14,42 @@ import friday.model.alias.ReservedKeyword;
 
 public class AliasCommandTest {
 
-    private static final String VALID_ALIAS = "ls";
-    private static final String INVALID_KEYWORD = "a";
+    private static final Alias VALID_ALIAS = new Alias("ls");
+    private static final Alias INVALID_ALIAS = new Alias(AddCommand.COMMAND_WORD);
+    private static final ReservedKeyword VALID_KEYWORD = new ReservedKeyword(ListCommand.COMMAND_WORD);
+    private static final ReservedKeyword INVALID_KEYWORD = new ReservedKeyword("a");
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void execute_aliasAcceptedByModel_addSuccessful() {
-        Alias alias = new Alias(VALID_ALIAS);
-        ReservedKeyword keyword = new ReservedKeyword(ListCommand.COMMAND_WORD);
-        AliasCommand aliasCommand = new AliasCommand(alias, keyword);
+        AliasCommand aliasCommand = new AliasCommand(VALID_ALIAS, VALID_KEYWORD);
 
-        String expectedMessage = String.format(AliasCommand.MESSAGE_SUCCESS, alias);
+        String expectedMessage = String.format(AliasCommand.MESSAGE_SUCCESS, VALID_ALIAS);
 
         ModelManager expectedModel = new ModelManager(model.getFriday(), new UserPrefs());
-        expectedModel.addAlias(alias, keyword);
+        expectedModel.addAlias(VALID_ALIAS, VALID_KEYWORD);
 
         assertCommandSuccess(aliasCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_duplicateAlias_throwsCommandException() {
-        Alias alias = new Alias(VALID_ALIAS);
-        ReservedKeyword keyword = new ReservedKeyword(ListCommand.COMMAND_WORD);
-        AliasCommand aliasCommand = new AliasCommand(alias, keyword);
-        model.addAlias(alias, keyword);
+        AliasCommand aliasCommand = new AliasCommand(VALID_ALIAS, VALID_KEYWORD);
+        model.addAlias(VALID_ALIAS, VALID_KEYWORD);
 
         assertCommandFailure(aliasCommand, model, AliasCommand.MESSAGE_DUPLICATE_ALIAS);
     }
 
     @Test
     public void execute_invalidAlias_throwsCommandException() {
-        Alias alias = new Alias(AddCommand.COMMAND_WORD);
-        ReservedKeyword keyword = new ReservedKeyword(ListCommand.COMMAND_WORD);
-        AliasCommand aliasCommand = new AliasCommand(alias, keyword);
+        AliasCommand aliasCommand = new AliasCommand(INVALID_ALIAS, VALID_KEYWORD);
 
         assertCommandFailure(aliasCommand, model, AliasCommand.MESSAGE_INVALID_ALIAS);
     }
 
     @Test
     public void execute_invalidKeyword_throwsCommandException() {
-        Alias alias = new Alias(VALID_ALIAS);
-        ReservedKeyword keyword = new ReservedKeyword(INVALID_KEYWORD);
-        AliasCommand aliasCommand = new AliasCommand(alias, keyword);
+        AliasCommand aliasCommand = new AliasCommand(VALID_ALIAS, INVALID_KEYWORD);
 
         assertCommandFailure(aliasCommand, model, AliasCommand.MESSAGE_INVALID_KEYWORD);
     }

--- a/src/test/java/friday/logic/commands/SortCommandTest.java
+++ b/src/test/java/friday/logic/commands/SortCommandTest.java
@@ -149,11 +149,6 @@ public class SortCommandTest {
         }
 
         @Override
-        public boolean hasAlias(String key) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
         public void addAlias(Alias alias, ReservedKeyword keyword) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/friday/logic/parser/AliasCommandParserTest.java
+++ b/src/test/java/friday/logic/parser/AliasCommandParserTest.java
@@ -15,15 +15,15 @@ import friday.model.alias.ReservedKeyword;
 
 public class AliasCommandParserTest {
 
-    private static final String VALID_ALIAS = "ls";
+    private static final Alias VALID_ALIAS = new Alias("ls");
+    private static final ReservedKeyword VALID_KEYWORD = new ReservedKeyword(ListCommand.COMMAND_WORD);
     private static final String INVALID_PREFIX = "g/ ";
     private static final String VALID_ALIAS_ARG = " " + PREFIX_ALIAS + VALID_ALIAS;
     private static final String VALID_RESERVED_KEYWORD_ARG = " " + PREFIX_RESERVED_KEYWORD + ListCommand.COMMAND_WORD;
     private static final String INVALID_ARGS_1 = INVALID_PREFIX + VALID_ALIAS + VALID_RESERVED_KEYWORD_ARG;
     private static final String INVALID_ARGS_2 = VALID_ALIAS_ARG + INVALID_PREFIX + ListCommand.COMMAND_WORD;
     private AliasCommandParser parser = new AliasCommandParser();
-    private AliasCommand expectedCommand = new AliasCommand(new Alias(VALID_ALIAS),
-            new ReservedKeyword(ListCommand.COMMAND_WORD));
+    private AliasCommand expectedCommand = new AliasCommand(VALID_ALIAS, VALID_KEYWORD);
 
     @Test
     public void parse_validArgs_returnsAliasCommand() {

--- a/src/test/java/friday/logic/parser/UnaliasCommandParserTest.java
+++ b/src/test/java/friday/logic/parser/UnaliasCommandParserTest.java
@@ -12,13 +12,13 @@ import friday.model.alias.Alias;
 
 public class UnaliasCommandParserTest {
 
-    private static final String VALID_ALIAS = "ls";
+    private static final Alias VALID_ALIAS = new Alias("ls");
     private static final String INVALID_PREFIX = "g/";
     private static final String VALID_ARGS = " " + PREFIX_ALIAS + VALID_ALIAS;
     private static final String INVALID_ARGS = " " + INVALID_PREFIX + VALID_ALIAS;
 
     private UnaliasCommandParser parser = new UnaliasCommandParser();
-    private UnaliasCommand expectedCommand = new UnaliasCommand(new Alias(VALID_ALIAS));
+    private UnaliasCommand expectedCommand = new UnaliasCommand(VALID_ALIAS);
 
     @Test
     public void parse_validArgs_returnsUnaliasCommand() {

--- a/src/test/java/friday/model/MasteryCheckBookTest.java
+++ b/src/test/java/friday/model/MasteryCheckBookTest.java
@@ -15,6 +15,8 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import friday.logic.commands.CommandTestUtil;
+import friday.model.alias.Alias;
+import friday.model.alias.ReservedKeyword;
 import friday.model.student.Student;
 import friday.model.student.exceptions.DuplicateStudentException;
 import friday.testutil.StudentBuilder;
@@ -103,7 +105,7 @@ public class MasteryCheckBookTest {
         }
 
         @Override
-        public Set<Map.Entry<String, String>> getAliasMap() {
+        public Set<Map.Entry<Alias, ReservedKeyword>> getAliasMap() {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/friday/model/alias/AliasMapTest.java
+++ b/src/test/java/friday/model/alias/AliasMapTest.java
@@ -13,7 +13,8 @@ import friday.model.alias.exceptions.DuplicateAliasException;
 
 public class AliasMapTest {
 
-    private static final String VALID_ALIAS = "ls";
+    private static final Alias VALID_ALIAS = new Alias("ls");
+    private static final ReservedKeyword VALID_KEYWORD = new ReservedKeyword(ListCommand.COMMAND_WORD);
 
     private final AliasMap aliasMap = new AliasMap();
 
@@ -29,22 +30,20 @@ public class AliasMapTest {
 
     @Test
     public void contains_aliasInMap_returnsTrue() {
-        aliasMap.add(new Alias(VALID_ALIAS), new ReservedKeyword(ListCommand.COMMAND_WORD));
+        aliasMap.add(VALID_ALIAS, VALID_KEYWORD);
         assertTrue(aliasMap.contains(VALID_ALIAS));
     }
 
     @Test
     public void add_nullAlias_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> aliasMap.add(null,
-                new ReservedKeyword(ListCommand.COMMAND_WORD)));
-        assertThrows(NullPointerException.class, () -> aliasMap.add(new Alias(VALID_ALIAS), null));
+        assertThrows(NullPointerException.class, () -> aliasMap.add(null, VALID_KEYWORD));
+        assertThrows(NullPointerException.class, () -> aliasMap.add(VALID_ALIAS, null));
     }
 
     @Test
     public void add_duplicateAlias_throwsDuplicateAliasException() {
-        aliasMap.add(new Alias(VALID_ALIAS), new ReservedKeyword(ListCommand.COMMAND_WORD));
-        assertThrows(DuplicateAliasException.class, () -> aliasMap.add(new Alias(VALID_ALIAS),
-                new ReservedKeyword(ListCommand.COMMAND_WORD)));
+        aliasMap.add(VALID_ALIAS, VALID_KEYWORD);
+        assertThrows(DuplicateAliasException.class, () -> aliasMap.add(VALID_ALIAS, VALID_KEYWORD));
     }
 
     @Test
@@ -54,13 +53,13 @@ public class AliasMapTest {
 
     @Test
     public void remove_aliasDoesNotExist_throwsAliasNotFoundException() {
-        assertThrows(AliasNotFoundException.class, () -> aliasMap.remove(new Alias(VALID_ALIAS)));
+        assertThrows(AliasNotFoundException.class, () -> aliasMap.remove(VALID_ALIAS));
     }
 
     @Test
     public void remove_existingAlias_removesAlias() {
-        aliasMap.add(new Alias(VALID_ALIAS), new ReservedKeyword(ListCommand.COMMAND_WORD));
-        aliasMap.remove(new Alias(VALID_ALIAS));
+        aliasMap.add(VALID_ALIAS, VALID_KEYWORD);
+        aliasMap.remove(VALID_ALIAS);
         AliasMap expectedAliasMap = new AliasMap();
         assertEquals(expectedAliasMap, aliasMap);
     }

--- a/src/test/java/friday/model/alias/AliasTest.java
+++ b/src/test/java/friday/model/alias/AliasTest.java
@@ -25,12 +25,12 @@ public class AliasTest {
         assertThrows(NullPointerException.class, () -> Alias.isValidAlias(null));
 
         // invalid alias
-        assertFalse(Alias.isValidAlias(new Alias(AddCommand.COMMAND_WORD))); // alias in reserved keyword
-        assertFalse(Alias.isValidAlias(new Alias(DeleteCommand.COMMAND_WORD))); // alias in reserved keyword
+        assertFalse(Alias.isValidAlias(AddCommand.COMMAND_WORD)); // alias in reserved keyword
+        assertFalse(Alias.isValidAlias(DeleteCommand.COMMAND_WORD)); // alias in reserved keyword
 
         // valid name
-        assertTrue(Alias.isValidAlias(new Alias(VALID_ALIAS_1))); // valid alias
-        assertTrue(Alias.isValidAlias(new Alias(VALID_ALIAS_2))); // valid alias
+        assertTrue(Alias.isValidAlias(VALID_ALIAS_1)); // valid alias
+        assertTrue(Alias.isValidAlias(VALID_ALIAS_2)); // valid alias
     }
 }
 


### PR DESCRIPTION
Add grade command to list of reserved keywords

Standardize input of Alias#isValidAlias(String test) and ReservedKeyword#isValidReservedKeyword(String test) to both take in String

Change internalMap in AliasMap to store <Alias, ReservedKeyword>

Update affected methods accordingly