### PR TITLE
Fix UI bug in MarkMasteryCheckCommand and UnmarkMasteryCheckCommand

### DIFF
--- a/src/main/java/friday/logic/commands/MarkMasteryCheckCommand.java
+++ b/src/main/java/friday/logic/commands/MarkMasteryCheckCommand.java
@@ -42,7 +42,6 @@ public class MarkMasteryCheckCommand extends Command {
             studentToMark.getMasteryCheck().markAsPassed();
         }
 
-        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
         return new CommandResult(generateSuccessMessage(studentToMark));
     }
 

--- a/src/main/java/friday/logic/commands/MarkMasteryCheckCommand.java
+++ b/src/main/java/friday/logic/commands/MarkMasteryCheckCommand.java
@@ -1,7 +1,5 @@
 package friday.logic.commands;
 
-import static friday.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
-
 import java.util.List;
 
 import friday.commons.core.Messages;

--- a/src/main/java/friday/logic/commands/UnmarkMasteryCheckCommand.java
+++ b/src/main/java/friday/logic/commands/UnmarkMasteryCheckCommand.java
@@ -42,7 +42,6 @@ public class UnmarkMasteryCheckCommand extends Command {
             studentToUnmark.getMasteryCheck().unmark();
         }
 
-        model.updateFilteredStudentList(PREDICATE_SHOW_ALL_STUDENTS);
         return new CommandResult(generateSuccessMessage(studentToUnmark));
     }
 

--- a/src/main/java/friday/logic/commands/UnmarkMasteryCheckCommand.java
+++ b/src/main/java/friday/logic/commands/UnmarkMasteryCheckCommand.java
@@ -1,7 +1,5 @@
 package friday.logic.commands;
 
-import static friday.model.Model.PREDICATE_SHOW_ALL_STUDENTS;
-
 import java.util.List;
 
 import friday.commons.core.Messages;

--- a/src/main/java/friday/model/alias/ReservedKeyword.java
+++ b/src/main/java/friday/model/alias/ReservedKeyword.java
@@ -20,6 +20,8 @@ import friday.logic.commands.RemarkCommand;
 import friday.logic.commands.SortCommand;
 import friday.logic.commands.UgCommand;
 import friday.logic.commands.UnaliasCommand;
+import friday.logic.commands.UnmarkMasteryCheckCommand;
+
 
 /**
  * Represents a ReservedKeyword in friday.
@@ -31,7 +33,7 @@ public class ReservedKeyword {
             DeleteCommand.COMMAND_WORD, EditCommand.COMMAND_WORD, ExitCommand.COMMAND_WORD, FindCommand.COMMAND_WORD,
             GradeCommand.COMMAND_WORD, HelpCommand.COMMAND_WORD, ListCommand.COMMAND_WORD,
             MarkMasteryCheckCommand.COMMAND_WORD, RemarkCommand.COMMAND_WORD, SortCommand.COMMAND_WORD,
-            UgCommand.COMMAND_WORD, UnaliasCommand.COMMAND_WORD);
+            UgCommand.COMMAND_WORD, UnaliasCommand.COMMAND_WORD, UnmarkMasteryCheckCommand.COMMAND_WORD);
 
     public static final String MESSAGE_CONSTRAINTS = "Reserved keyword given is not in the list of reserved keywords";
 

--- a/src/main/java/friday/ui/StudentListPanel.java
+++ b/src/main/java/friday/ui/StudentListPanel.java
@@ -34,6 +34,8 @@ public class StudentListPanel extends UiPart<Region> {
      */
     public void setList(ObservableList<Student> studentList) {
         studentListView.setItems(studentList);
+
+        studentListView.setCellFactory((listView -> new StudentListViewCell()));
     }
 
     /**


### PR DESCRIPTION
Fix bug where "(passed)" string is not shown or deleted when a student is marked or unmarked respectively