### PR TITLE
Fix bugs from PE-D

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -59,7 +59,7 @@ type fast, FRIDAY can get your contact management tasks done faster than traditi
 
   e.g. if the command specifies `n/NAME t/TELEGRAM_HANDLE`, `t/TELEGRAM_HANDLE n/NAME` is also acceptable.
 
-* If a parameter is expected only once in the command, but you specified it multiple times, only the last occurrence of the parameter will be taken.<br>
+* If a parameter is expected only once in the command, but you specified it multiple times, only the last occurrence of the parameter will be taken. Note that this does not apply to the `INDEX` parameter in commands that have it, namely the `delete`, `edit`, `remark`, `grade`, `mark` and `unmark` commands, as they expect exactly one `INDEX` parameter.<br>
 
   e.g. if you specify `t/johndoe t/johndoe123`, only `t/johndoe123` will be taken.
 
@@ -92,6 +92,7 @@ Deletes the student at the given index from FRIDAY.
 Format: `delete INDEX`
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+The index of the student must be specified and there should be exactly one INDEX parameter.<br>
 The index of the student can be seen from the student list.
 </div>
 
@@ -102,6 +103,7 @@ Edits a student's details in FRIDAY.
 Format: `edit INDEX [n/NAME] [t/TELEGRAM_HANDLE] [c/CONSULTATION] [m/MASTERY_CHECK] [tag/TAG]`
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+The index of the student must be specified and there should be exactly one INDEX parameter.<br>
 The index of the student can be seen from the student list.<br>
 The name, Telegram handle, consultation, mastery check, and tag(s) are optional, but there should be at least one parameter.<br>
 A student can have any number of tags (including 0).
@@ -114,6 +116,7 @@ Adds a remark for a specified student.
 Format: `remark INDEX [r/REMARK]`
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+The index of the student must be specified and there should be exactly one INDEX parameter.<br>
 The index of the student can be seen from the student list.<br>
 The remark is optional. Not including the remark (i.e. `remark INDEX`) will remove any existing remark from the student.<br>
 </div>
@@ -125,6 +128,7 @@ Records the grades of the assessments and examinations for a specified student.
 Format: `grade INDEX [ra1/RA1_SCORE] [ra2/RA2_SCORE] [pa/PRACTICAL_SCORE] [mt/MID_TERM_SCORE] [ft/FINALS_SCORE]`
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+The index of the student must be specified and there should be exactly one INDEX parameter.<br>
 The index of the student can be seen from the student list.<br>
 The scores of the assessments, Reading Assessment 1 (RA1), Reading Assessment 2 (RA2), Practical Assessment (PA), Midterm Test, and Final Examination, are in percentages from 0% to 100% inclusive, with decimals allowed.<br>
 The scores are optional, but there should be at least one parameter.
@@ -164,6 +168,7 @@ Marks the Mastery Check of a specified student as passed.
 Format: `mark INDEX`
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+The index of the student must be specified and there should be exactly one INDEX parameter.<br>
 The index of the student can be seen from the student list.<br>
 </div>
 
@@ -177,6 +182,7 @@ Unmarks the Mastery Check of a specified student.
 Format: `unmark INDEX`
 
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+The index of the student must be specified and there should be exactly one INDEX parameter.<br>
 The index of the student can be seen from the student list.<br>
 </div>
 
@@ -246,11 +252,11 @@ Format: `help`
 | Action                                       | Format                                                                                                   |
 |----------------------------------------------|----------------------------------------------------------------------------------------------------------|
 | **Add a student**                            | `add n/NAME [t/TELEGRAM_HANDLE] [c/CONSULTATION_DATE] [m/MASTERY_CHECK_DATE] [tag/TAG]...`               |
-| **Delete a student**                         | `delete i/INDEX`                                                                                         |
+| **Delete a student**                         | `delete INDEX`                                                                                           |
 | **Edit a student's details**                 | `edit INDEX [n/NAME] [t/TELEGRAM_HANDLE] [c/CONSULTATION] [m/MASTERY_CHECK] [tag/TAG]...`                |
 | **Add remarks for a student**                | `remark INDEX [r/REMARK]`                                                                                |
 | **Record the grades for a student**          | `grade INDEX [ra1/RA1_SCORE] [ra2/RA2_SCORE] [pa/PRACTICAL_SCORE] [mt/MID_TERM_SCORE] [ft/FINALS_SCORE]` |
-| **Find a student's details**                 | `find k/keyword`                                                                                         |
+| **Find a student's details**                 | `find keyword`                                                                                           |
 | **Mark a student's Mastery Check as passed** | `mark INDEX`                                                                                             |
 | **Unmark a student's Mastery Check**         | `unmark INDEX`                                                                                           |
 | **View all students**                        | `list`                                                                                                   |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -130,7 +130,7 @@ Format: `grade INDEX [ra1/RA1_SCORE] [ra2/RA2_SCORE] [pa/PRACTICAL_SCORE] [mt/MI
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
 The index of the student must be specified and there should be exactly one INDEX parameter.<br>
 The index of the student can be seen from the student list.<br>
-The scores of the assessments, Reading Assessment 1 (RA1), Reading Assessment 2 (RA2), Practical Assessment (PA), Midterm Test, and Final Examination, are in percentages from 0% to 100% inclusive, with decimals allowed.<br>
+The scores of the assessments, Reading Assessment 1 (RA1), Reading Assessment 2 (RA2), Practical Assessment (PA), Midterm Test, and Final Examination, are in percentages between 0% to 100% inclusive, with up to 2 decimals allowed.<br>
 The scores are optional, but there should be at least one parameter.
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -256,7 +256,7 @@ Format: `help`
 | **Edit a student's details**                 | `edit INDEX [n/NAME] [t/TELEGRAM_HANDLE] [c/CONSULTATION] [m/MASTERY_CHECK] [tag/TAG]...`                |
 | **Add remarks for a student**                | `remark INDEX [r/REMARK]`                                                                                |
 | **Record the grades for a student**          | `grade INDEX [ra1/RA1_SCORE] [ra2/RA2_SCORE] [pa/PRACTICAL_SCORE] [mt/MID_TERM_SCORE] [ft/FINALS_SCORE]` |
-| **Find a student's details**                 | `find keyword`                                                                                           |
+| **Find a student's details**                 | `find k/keyword`                                                                                         |
 | **Mark a student's Mastery Check as passed** | `mark INDEX`                                                                                             |
 | **Unmark a student's Mastery Check**         | `unmark INDEX`                                                                                           |
 | **View all students**                        | `list`                                                                                                   |

--- a/src/main/java/friday/logic/commands/EditCommand.java
+++ b/src/main/java/friday/logic/commands/EditCommand.java
@@ -43,7 +43,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_TELEGRAMHANDLE + "TELEGRAM HANDLE] "
             + "[" + PREFIX_CONSULTATION + "CONSULTATION] "
             + "[" + PREFIX_MASTERYCHECK + "MASTERY CHECK] "
-            + "[" + PREFIX_TAG + "TAG]\n"
+            + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_TELEGRAMHANDLE + "johndoe "
             + PREFIX_CONSULTATION + "2022-09-01 "

--- a/src/main/java/friday/model/grades/Grade.java
+++ b/src/main/java/friday/model/grades/Grade.java
@@ -10,7 +10,8 @@ import java.util.Objects;
  */
 public class Grade {
 
-    public static final String MESSAGE_CONSTRAINTS = "Grades should be in percentages, excluding the % sign.";
+    public static final String MESSAGE_CONSTRAINTS = "Grades should be in percentages, between 0 and 100, "
+            + "excluding the % sign.";
     public static final String VALIDATION_REGEX = "^((100)|(\\d{1,2}(\\.\\d*)?))$";
 
     public final String examName;

--- a/src/main/java/friday/model/grades/Grade.java
+++ b/src/main/java/friday/model/grades/Grade.java
@@ -11,8 +11,8 @@ import java.util.Objects;
 public class Grade {
 
     public static final String MESSAGE_CONSTRAINTS = "Grades should be in percentages, between 0 and 100, "
-            + "excluding the % sign.";
-    public static final String VALIDATION_REGEX = "^((100)|(\\d{1,2}(\\.\\d*)?))$";
+            + "up to 2 decimal places, excluding the % sign.";
+    public static final String VALIDATION_REGEX = "^(100(\\.0{1,2})?|[1-9]?\\d(\\.\\d{1,2})?)$";
 
     public final String examName;
     public final String score;

--- a/src/main/java/friday/model/student/TelegramHandle.java
+++ b/src/main/java/friday/model/student/TelegramHandle.java
@@ -11,9 +11,9 @@ public class TelegramHandle implements Comparable<TelegramHandle> {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Telegram handle should only contain letters a-z, numbers 0-9, and underscores; it should also be at least "
-                    + "5 characters long";
-    public static final String VALIDATION_REGEX = "[a-zA-Z0-9_]{5,}";
+            "Telegram handle should only contain letters a-z, numbers 0-9, and underscores; it should also be between "
+                    + "5 and 32 characters long";
+    public static final String VALIDATION_REGEX = "[a-zA-Z0-9_]{5,32}";
 
     public static final TelegramHandle EMPTY_TELEGRAMHANDLE = new TelegramHandle();
 

--- a/src/main/java/friday/model/tag/Tag.java
+++ b/src/main/java/friday/model/tag/Tag.java
@@ -9,8 +9,9 @@ import static java.util.Objects.requireNonNull;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric. Whitespaces are allowed.";
-    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9 ]*$";
+    public static final String MESSAGE_CONSTRAINTS = "Tags' names should be alphanumeric and limited to 20 characters. "
+            + "Whitespaces are allowed.";
+    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9 ]{0,20}$";
 
     public final String tagName;
 

--- a/src/test/java/friday/model/grade/GradeTest.java
+++ b/src/test/java/friday/model/grade/GradeTest.java
@@ -51,11 +51,10 @@ public class GradeTest {
         // invalid score
         assertFalse(Grade.isValidScore("a"));
         assertFalse(Grade.isValidScore("-1"));
-        assertFalse(Grade.isValidScore("100.0"));
 
         // valid score
         assertTrue(Grade.isValidScore(VALID_SCORE_1));
         assertTrue(Grade.isValidScore(VALID_SCORE_2));
-        assertTrue(Grade.isValidScore("69.420"));
+        assertTrue(Grade.isValidScore("69.42"));
     }
 }


### PR DESCRIPTION
#136 - Update prefix in command summary for delete and find commands
#139 - Limit the length of tags
#144 - Limit the length of Telegram handle to 32 char
#160 - Update error message for invalid grades
#169 - Update UG to be more specific in handling INDEX parameter for
commands.
#164 - Fix bug with regex for grades