### PR TITLE
Alias bug fix

### DIFF
--- a/src/main/java/friday/logic/commands/AliasCommand.java
+++ b/src/main/java/friday/logic/commands/AliasCommand.java
@@ -26,7 +26,8 @@ public class AliasCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New alias added: %1$s";
     public static final String MESSAGE_DUPLICATE_ALIAS = "This alias already exists in FRIDAY";
-    public static final String MESSAGE_INVALID_ALIAS = "Alias cannot be a reserved keyword";
+    public static final String MESSAGE_INVALID_ALIAS = "Alias given is invalid.\n"
+            + "Alias cannot be a reserved keyword and cannot contain more than 1 word";
     public static final String MESSAGE_INVALID_KEYWORD = "Keyword given is not a reserved keyword";
 
     private final Alias toAdd;

--- a/src/main/java/friday/logic/commands/AliasCommand.java
+++ b/src/main/java/friday/logic/commands/AliasCommand.java
@@ -27,7 +27,7 @@ public class AliasCommand extends Command {
     public static final String MESSAGE_SUCCESS = "New alias added: %1$s";
     public static final String MESSAGE_DUPLICATE_ALIAS = "This alias already exists in FRIDAY";
     public static final String MESSAGE_INVALID_ALIAS = "Alias given is invalid.\n"
-            + "Alias cannot be a reserved keyword and cannot contain more than 1 word";
+            + "Alias cannot be a reserved keyword and must contain only 1 word.";
     public static final String MESSAGE_INVALID_KEYWORD = "Keyword given is not a reserved keyword";
 
     private final Alias toAdd;

--- a/src/main/java/friday/model/alias/Alias.java
+++ b/src/main/java/friday/model/alias/Alias.java
@@ -8,6 +8,7 @@ import static java.util.Objects.requireNonNull;
 public class Alias {
 
     private final String value;
+    private static final String SPACE = " ";
 
     /**
      * Constructs an {@code Alias}.
@@ -23,7 +24,7 @@ public class Alias {
      * Returns if a given String is a valid alias.
      */
     public static boolean isValidAlias(String test) {
-        return !ReservedKeyword.LIST_RESERVED_KEYWORDS.contains(test);
+        return !ReservedKeyword.LIST_RESERVED_KEYWORDS.contains(test) && !test.contains(SPACE);
     }
 
     @Override

--- a/src/main/java/friday/model/alias/Alias.java
+++ b/src/main/java/friday/model/alias/Alias.java
@@ -9,6 +9,7 @@ public class Alias {
 
     private final String value;
     private static final String SPACE = " ";
+    private static final String EMPTY_STRING = "";
 
     /**
      * Constructs an {@code Alias}.
@@ -24,7 +25,9 @@ public class Alias {
      * Returns if a given String is a valid alias.
      */
     public static boolean isValidAlias(String test) {
-        return !ReservedKeyword.LIST_RESERVED_KEYWORDS.contains(test) && !test.contains(SPACE);
+        return !ReservedKeyword.LIST_RESERVED_KEYWORDS.contains(test)
+                && !test.contains(SPACE)
+                && !test.equals(EMPTY_STRING);
     }
 
     @Override

--- a/src/main/java/friday/model/alias/Alias.java
+++ b/src/main/java/friday/model/alias/Alias.java
@@ -7,10 +7,9 @@ import static java.util.Objects.requireNonNull;
  */
 public class Alias {
 
-    private final String value;
     private static final String SPACE = " ";
     private static final String EMPTY_STRING = "";
-
+    private final String value;
     /**
      * Constructs an {@code Alias}.
      *

--- a/src/main/java/friday/storage/JsonSerializableFriday.java
+++ b/src/main/java/friday/storage/JsonSerializableFriday.java
@@ -22,8 +22,9 @@ import friday.model.student.Student;
 class JsonSerializableFriday {
 
     public static final String MESSAGE_DUPLICATE_STUDENT = "Students list contains duplicate student(s).";
-    public static final String MESSAGE_INVALID_KEYWORD = "Alias map contains invalid mapping(s)";
+    public static final String MESSAGE_INVALID_KEYWORD = "Alias map contains invalid keyword(s)";
     public static final String MESSAGE_DUPLICATE_ALIAS = "Alias map contains duplicate alias(es).";
+    public static final String MESSAGE_INVALID_ALIAS = "Alias map contains invalid alias(es).";
 
     private final List<JsonAdaptedStudent> students = new ArrayList<>();
     private final List<JsonAdaptedAlias> aliases = new ArrayList<>();
@@ -67,6 +68,9 @@ class JsonSerializableFriday {
             ReservedKeyword keyword = jsonAdaptedAlias.toReservedKeywordModelType();
             if (!ReservedKeyword.isValidReservedKeyword(keyword.toString())) {
                 throw new IllegalValueException(MESSAGE_INVALID_KEYWORD);
+            }
+            if (!Alias.isValidAlias(alias.toString())) {
+                throw new IllegalValueException(MESSAGE_INVALID_ALIAS);
             }
             if (friday.hasAlias(alias)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_ALIAS);


### PR DESCRIPTION
Fix #155 by defining a valid alias as one word
Fix #143 by defining a valid alias as non-empty