### PR TITLE
Fix bug where more than 1 Mastery Check is marked in the same command

### DIFF
--- a/src/main/java/friday/logic/commands/MarkMasteryCheckCommand.java
+++ b/src/main/java/friday/logic/commands/MarkMasteryCheckCommand.java
@@ -21,6 +21,8 @@ public class MarkMasteryCheckCommand extends Command {
     public static final String MESSAGE_ALREADY_MARKED = "'s Mastery Check has already been marked as passed!";
     public static final String MESSAGE_CANNOT_PASS = "'s Mastery Check cannot be marked as passed as the date(%s) has"
             + " not been reached yet. (Today's date: %s)";
+    public static final String MESSAGE_EMPTY_MASTERYCHECK = " currently does not have any scheduled Mastery Check to be"
+            + " marked as passed.";
 
     private Index index;
 
@@ -37,9 +39,11 @@ public class MarkMasteryCheckCommand extends Command {
         }
 
         Student studentToMark = lastShownList.get(index.getZeroBased());
-        if (studentToMark.getMasteryCheck().getIsPassed()) {
+        if (studentToMark.getMasteryCheck().isEmpty()) {
+            throw new CommandException(studentToMark.getName() + MESSAGE_EMPTY_MASTERYCHECK);
+        } else if (studentToMark.getMasteryCheck().getIsPassed()) {
             throw new CommandException(studentToMark.getName() + MESSAGE_ALREADY_MARKED);
-        } else if (!studentToMark.getMasteryCheck().canPass()) {
+        } else if (!studentToMark.getMasteryCheck().canMarkAsPassed()) {
             String str = String.format(MESSAGE_CANNOT_PASS, studentToMark.getMasteryCheck().getValue(),
                     LocalDate.now());
             throw new CommandException(studentToMark.getName() + str);

--- a/src/main/java/friday/logic/commands/UnmarkMasteryCheckCommand.java
+++ b/src/main/java/friday/logic/commands/UnmarkMasteryCheckCommand.java
@@ -18,6 +18,8 @@ public class UnmarkMasteryCheckCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1 ";
     public static final String MESSAGE_NOT_MARKED = "Can't unmark as %s's Mastery Check has not been marked as passed!";
+    public static final String MESSAGE_EMPTY_MASTERYCHECK = " currently does not have any scheduled Mastery Check to be"
+            + " unmarked.";
 
     private Index index;
 
@@ -34,7 +36,9 @@ public class UnmarkMasteryCheckCommand extends Command {
         }
 
         Student studentToUnmark = lastShownList.get(index.getZeroBased());
-        if (!studentToUnmark.getMasteryCheck().getIsPassed()) {
+        if (studentToUnmark.getMasteryCheck().isEmpty()) {
+            throw new CommandException(studentToUnmark.getName() + MESSAGE_EMPTY_MASTERYCHECK);
+        } else if (!studentToUnmark.getMasteryCheck().getIsPassed()) {
             throw new CommandException(String.format(MESSAGE_NOT_MARKED, studentToUnmark.getName()));
         } else {
             studentToUnmark.getMasteryCheck().unmark();

--- a/src/main/java/friday/model/student/MasteryCheck.java
+++ b/src/main/java/friday/model/student/MasteryCheck.java
@@ -113,8 +113,16 @@ public class MasteryCheck implements Comparable<MasteryCheck> {
         this.isPassed = false;
     }
 
-    public boolean canPass() {
-        return this.value.isBefore(LocalDate.now());
+    /**
+     * Checks if a Mastery Check can be marked as passed. Returns false if the given Mastery Check is empty or if its
+     * value is before the current date, and true otherwise.
+     */
+    public boolean canMarkAsPassed() {
+        if (!this.isEmpty()) {
+            return this.value.isBefore(LocalDate.now());
+        } else {
+            return false;
+        }
     }
 
     @Override


### PR DESCRIPTION
This occurred when marking students with empty Mastery Checks, as these students share the same static instance of `EMPTY_MASTERYCHECK`.

Fixed by adding `isEmpty()` checks to the `execute` commands of `MarkMasteryCheckCommand` and `UnmarkMasteryCheckCommand` to disallow marking and unmarking empty Mastery Checks.